### PR TITLE
Update feature/cssClasses: code duplication

### DIFF
--- a/scripts/buildCss.js
+++ b/scripts/buildCss.js
@@ -5,23 +5,17 @@ const fs = require('fs'),
 // npm packages
 const simpleIcons = require('simple-icons')
 
+// utils
+const { titleToFilename } = require('../lib/utils')
+
 
 const basePath = path.join(__dirname, '..')
 
 const attributedIcons = Object.values(simpleIcons).map(icon => {
 	return {
 		color: icon.hex,
-		cssClass: icon.title
-			.toLowerCase()
-			.replace(/[ !’]/g, '')
-			.replace(/-/g, '_') // hyphens not supported in ligatures
-			.replace(/\./g, 'dot') // dot not supported in css class names
-			.replace(/\+/g, 'plus') // plus not supported in css class names
-			.replace(/&/g, 'and') // ampersand not supported in css class names
-		,
-		ligature: icon.title
-			.replace(/[ !’]/g, '')
-			.replace(/-/g, '_') // hyphens not supported in ligatures
+		cssClass: titleToFilename(icon.title),
+		ligature: titleToFilename(icon.title)
 	}
 })
 

--- a/scripts/buildTestpage.js
+++ b/scripts/buildTestpage.js
@@ -6,19 +6,16 @@ const fs = require('fs'),
 const pug = require('pug'),
       simpleIcons = require('simple-icons')
 
+// utils
+const { titleToFilename } = require('../lib/utils')
+
 
 const basePath = path.join(__dirname, '..')
 
 const attributedIcons = Object.values(simpleIcons).map(icon => {
 	return {
 		name: icon.title,
-		cssClass: icon.title
-			.toLowerCase()
-			.replace(/[ !’]/g, '')
-			.replace(/-/g, '_') // hyphens not supported in ligatures
-			.replace(/\./g, 'dot') // dot not supported in css class names
-			.replace(/\+/g, 'plus') // plus not supported in css class names
-			.replace(/&/g, 'and') // ampersand not supported in css class names
+		cssClass: titleToFilename(icon.title)
 	}
 })
 


### PR DESCRIPTION
Use `titleToFilename` for CSS class name to reduce code duplication and to increase consistency in naming between the main package and this font.

Addresses https://github.com/simple-icons/simple-icons-font/pull/6#discussion_r304272040 and https://github.com/simple-icons/simple-icons-font/pull/6#discussion_r304274604